### PR TITLE
Fix: process.env.* not being replaced with values in bundles

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -45,8 +45,10 @@ const createNativeEntry = () => {
         external,
         plugins: [
             replace({
-              'process.env.PRODUCT_NAME': JSON.stringify(PRODUCT_NAME),
-              'process.env.PRODUCT_VERSION': JSON.stringify(packageJson.version),
+                replaces: {
+                    'process.env.PRODUCT_NAME': JSON.stringify(PRODUCT_NAME),
+                    'process.env.PRODUCT_VERSION': JSON.stringify(packageJson.version),
+                }
             }),
             nodeResolve({ browser: true }),
             commonjs(),
@@ -90,8 +92,10 @@ const createBrowserEntry = (target, cryptoType, format) => {
         },
         plugins: [
             replace({
-              'process.env.PRODUCT_NAME': JSON.stringify(PRODUCT_NAME),
-              'process.env.PRODUCT_VERSION': JSON.stringify(packageJson.version),
+                replaces: {
+                    'process.env.PRODUCT_NAME': JSON.stringify(PRODUCT_NAME),
+                    'process.env.PRODUCT_VERSION': JSON.stringify(packageJson.version),
+                }
             }),
             replace({
                 patterns: [
@@ -151,8 +155,10 @@ const createNodeJsEntry = (cryptoType, format) => {
         external,
         plugins: [
             replace({
-              'process.env.PRODUCT_NAME': JSON.stringify(PRODUCT_NAME),
-              'process.env.PRODUCT_VERSION': JSON.stringify(packageJson.version),
+                replaces: {
+                    'process.env.PRODUCT_NAME': JSON.stringify(PRODUCT_NAME),
+                    'process.env.PRODUCT_VERSION': JSON.stringify(packageJson.version),
+                }
             }),
             replace({
                 patterns: [


### PR DESCRIPTION
References to `process.env` remained in bundles due to a misconfiguration of Rollup plugin that was meant to replace them with actual values. This caused `ReferenceError: process is not defined` when using UMD bundle in a browser. And it also caused VirgilAgent header to not include the product and version info.