### PR TITLE
feat!: throw specific error when private key cannot be found

### DIFF
--- a/packages/e3kit-base/src/AbstractEThree.ts
+++ b/packages/e3kit-base/src/AbstractEThree.ts
@@ -13,6 +13,7 @@ import {
     UsersFoundWithMultipleCardsError,
     GroupError,
     GroupErrorCode,
+    MissingPrivateKeyError,
 } from './errors';
 import { PrivateKeyLoader } from './PrivateKeyLoader';
 import { isArray, isString, isVirgilCard, isFindUsersResult, isLookupResult } from './typeguards';
@@ -246,7 +247,7 @@ export abstract class AbstractEThree {
         const shouldReturnString = isString(message);
 
         const privateKey = await this.keyLoader.loadLocalPrivateKey();
-        if (!privateKey) throw new RegisterRequiredError();
+        if (!privateKey) throw new MissingPrivateKeyError();
 
         const publicKeys = this.getPublicKeysForEncryption(privateKey, recipients);
         if (!publicKeys) {
@@ -318,7 +319,7 @@ export abstract class AbstractEThree {
         const shouldReturnString = isString(message);
 
         const privateKey = await this.keyLoader.loadLocalPrivateKey();
-        if (!privateKey) throw new RegisterRequiredError();
+        if (!privateKey) throw new MissingPrivateKeyError();
 
         const senderPublicKey = this.getPublicKeyForVerification(
             privateKey,
@@ -489,7 +490,7 @@ export abstract class AbstractEThree {
      */
     async backupPrivateKey(pwd: string): Promise<void> {
         const privateKey = await this.keyLoader.loadLocalPrivateKey();
-        if (!privateKey) throw new RegisterRequiredError();
+        if (!privateKey) throw new MissingPrivateKeyError();
         await this.keyLoader.savePrivateKeyRemote(privateKey, pwd);
         return;
     }

--- a/packages/e3kit-base/src/GroupManager.ts
+++ b/packages/e3kit-base/src/GroupManager.ts
@@ -10,7 +10,7 @@ import { CardManager } from 'virgil-sdk';
 import { ICard, Ticket } from './types';
 import { CLOUD_GROUP_SESSIONS_ROOT, MAX_EPOCHS_IN_GROUP_SESSION } from './constants';
 import { PrivateKeyLoader } from './PrivateKeyLoader';
-import { GroupError, GroupErrorCode, RegisterRequiredError } from './errors';
+import { GroupError, GroupErrorCode, MissingPrivateKeyError } from './errors';
 import { Group } from './groups/Group';
 import { GroupLocalStorage, RetrieveOptions } from './GroupLocalStorage';
 import { isSafeInteger } from './utils/number';
@@ -201,8 +201,7 @@ export class GroupManager {
     private async getCloudTicketStorage() {
         const keyPair = await this._privateKeyLoader.loadLocalKeyPair();
         if (!keyPair) {
-            // TODO replace with PrivateKeyMissingError
-            throw new RegisterRequiredError();
+            throw new MissingPrivateKeyError();
         }
 
         const { virgilCrypto, accessTokenProvider, apiUrl } = this._privateKeyLoader.options;

--- a/packages/e3kit-base/src/errors.ts
+++ b/packages/e3kit-base/src/errors.ts
@@ -26,9 +26,9 @@ export class IdentityAlreadyExistsError extends SdkError {
 }
 
 /**
- * Error thrown by {@link EThree.encrypt}, {@link EThree.decrypt},
- * {@link Ethree.unregister} and {@link EThree.backupPrivateKey}
- * when current identity of E3kit instance is not registered.
+ * Error thrown by  {@link Ethree.unregister} and {@link EThree.rotatePrivateKey}
+ * when current identity of E3kit instance is not registered (i.e. there is
+ * no Virgil Card for the current identity in Virgil Cloud).
  */
 export class RegisterRequiredError extends SdkError {
     constructor() {
@@ -195,5 +195,24 @@ export enum GroupErrorCode {
 export class GroupError extends SdkError {
     constructor(public errorCode: GroupErrorCode, message: string) {
         super(message, 'GroupError', GroupError);
+    }
+}
+
+/**
+ * Error thrown when an attempt is made to retrieve the private key from the
+ * device's persistent storage, but no private key exists.
+ *
+ * Thrown by {@link EThree.encrypt}, {@link EThree.decrypt}, {@link EThree.backupPrivateKey},
+ * {@link EThree.createGroup}, {@link EThree.loadGroup}, {@link EThree.getGroup},
+ * {@link Group.encrypt}, {@link Group.decrypt}, {@link Group.update}, {@link Group.add},
+ * {@link Group.remove} and {@link Group.reAdd}.
+ */
+export class MissingPrivateKeyError extends SdkError {
+    constructor() {
+        super(
+            'No private key found on the device. You should call "register()" of "restorePrivateKey()"',
+            'MissingPrivateKeyError',
+            MissingPrivateKeyError,
+        );
     }
 }

--- a/packages/e3kit-base/src/groups/Group.ts
+++ b/packages/e3kit-base/src/groups/Group.ts
@@ -1,6 +1,6 @@
 import { IGroupSession, ICrypto, Data, FindUsersResult, NodeBuffer, Ticket } from '../types';
 import { PrivateKeyLoader } from '../PrivateKeyLoader';
-import { RegisterRequiredError, GroupError, GroupErrorCode, UsersNotFoundError } from '../errors';
+import { GroupError, GroupErrorCode, UsersNotFoundError, MissingPrivateKeyError } from '../errors';
 import { ICard } from '../types';
 import { CardManager } from 'virgil-sdk';
 import { GroupManager } from '../GroupManager';
@@ -68,7 +68,7 @@ export class Group {
         const shouldReturnString = isString(data);
         const privateKey = await this._privateKeyLoader.loadLocalPrivateKey();
         if (!privateKey) {
-            throw new RegisterRequiredError();
+            throw new MissingPrivateKeyError();
         }
 
         const encrypted = this._session.encrypt(data, privateKey);

--- a/packages/e3kit-browser/src/index.ts
+++ b/packages/e3kit-browser/src/index.ts
@@ -14,6 +14,7 @@ export {
     AbortError,
     GroupErrorCode,
     GroupError,
+    MissingPrivateKeyError,
     // types
     NodeBuffer,
     Data,

--- a/packages/e3kit-native/src/index.ts
+++ b/packages/e3kit-native/src/index.ts
@@ -14,6 +14,7 @@ export {
     AbortError,
     GroupErrorCode,
     GroupError,
+    MissingPrivateKeyError,
     // types
     NodeBuffer,
     Data,

--- a/packages/e3kit-node/src/index.ts
+++ b/packages/e3kit-node/src/index.ts
@@ -14,6 +14,7 @@ export {
     AbortError,
     GroupErrorCode,
     GroupError,
+    MissingPrivateKeyError,
     // types
     NodeBuffer,
     Data,

--- a/packages/e3kit-tests/src/common/EThree.test.ts
+++ b/packages/e3kit-tests/src/common/EThree.test.ts
@@ -403,7 +403,7 @@ describe('EThree', () => {
             try {
                 await sdk.backupPrivateKey('secret_pass');
             } catch (e) {
-                expect(e).to.be.instanceOf(MissingPrivateKey);
+                expect(e).to.be.instanceOf(MissingPrivateKeyError);
                 return;
             }
             expect.fail();

--- a/packages/e3kit-tests/src/common/EThree.test.ts
+++ b/packages/e3kit-tests/src/common/EThree.test.ts
@@ -12,6 +12,7 @@ import {
     WrongKeyknoxPasswordError,
     PrivateKeyAlreadyExistsError,
     PrivateKeyNoBackupError,
+    MissingPrivateKeyError,
     EThree,
 } from '@virgilsecurity/e3kit-node';
 import {
@@ -402,7 +403,7 @@ describe('EThree', () => {
             try {
                 await sdk.backupPrivateKey('secret_pass');
             } catch (e) {
-                expect(e).to.be.instanceOf(RegisterRequiredError);
+                expect(e).to.be.instanceOf(MissingPrivateKey);
                 return;
             }
             expect.fail();
@@ -550,12 +551,12 @@ describe('EThree', () => {
             try {
                 await sdk.encrypt('message');
             } catch (e) {
-                expect(e).to.be.instanceOf(RegisterRequiredError);
+                expect(e).to.be.instanceOf(MissingPrivateKeyError);
             }
             try {
                 await sdk.decrypt('message');
             } catch (e) {
-                expect(e).to.be.instanceOf(RegisterRequiredError);
+                expect(e).to.be.instanceOf(MissingPrivateKeyError);
                 return;
             }
             expect.fail();


### PR DESCRIPTION
BREAKING CHANGE: `EThree.encrypt`, `EThree.decrypt` and `EThree.backupPrivateKey`
now throw `MissingPrivateKeyError` instead of `RegisterRequiredError` when private key
is not found