### PR TITLE
e3kit-native 0.8.0-beta.0 + e3kit 0.8.0-beta.0

### DIFF
--- a/examples/ReactNativeSample/ios/Podfile
+++ b/examples/ReactNativeSample/ios/Podfile
@@ -3,6 +3,7 @@ require_relative '../node_modules/@react-native-community/cli-platform-ios/nativ
 
 target 'ReactNativeSample' do
   use_frameworks!
+  use_native_modules!
 
   # Pods for ReactNativeSample
   pod 'FBLazyVector', :path => "../node_modules/react-native/Libraries/FBLazyVector"
@@ -40,8 +41,6 @@ target 'ReactNativeSample' do
     inherit! :search_paths
     # Pods for testing
   end
-
-  use_native_modules!
 end
 
 target 'ReactNativeSample-tvOS' do
@@ -51,5 +50,4 @@ target 'ReactNativeSample-tvOS' do
     inherit! :search_paths
     # Pods for testing
   end
-
 end

--- a/examples/ReactNativeSample/ios/Podfile.lock
+++ b/examples/ReactNativeSample/ios/Podfile.lock
@@ -182,11 +182,6 @@ PODS:
     - React-cxxreact (= 0.61.2)
     - React-jsi (= 0.61.2)
   - React-jsinspector (0.61.2)
-  - react-native-virgil-crypto (0.4.0):
-    - React
-    - VirgilCrypto (= 5.2.0)
-    - VirgilCryptoFoundation (~> 0.11.0)
-    - VirgilCryptoPythia (~> 0.11.0)
   - React-RCTActionSheet (0.61.2):
     - React-Core/RCTActionSheetHeaders (= 0.61.2)
   - React-RCTAnimation (0.61.2):
@@ -222,23 +217,28 @@ PODS:
     - React-cxxreact (= 0.61.2)
     - React-jsi (= 0.61.2)
     - ReactCommon/jscallinvoker (= 0.61.2)
-  - RNCAsyncStorage (1.6.2):
+  - RNCAsyncStorage (1.7.1):
     - React
-  - RNKeychain (4.0.1):
+  - RNKeychain (4.0.5):
     - React
-  - VirgilCrypto (5.2.0):
-    - VirgilCryptoFoundation (~> 0.11.0)
-  - VirgilCryptoFoundation (0.11.0):
-    - VSCCrypto/Common (= 0.11.0)
-    - VSCCrypto/Foundation (= 0.11.0)
-  - VirgilCryptoPythia (0.11.0):
-    - VirgilCryptoFoundation (= 0.11.0)
-    - VSCCrypto/Common (= 0.11.0)
-    - VSCCrypto/Foundation (= 0.11.0)
-    - VSCCrypto/Pythia (= 0.11.0)
-  - VSCCrypto/Common (0.11.0)
-  - VSCCrypto/Foundation (0.11.0)
-  - VSCCrypto/Pythia (0.11.0)
+  - RNVirgilCrypto (0.5.0):
+    - React
+    - VirgilCrypto (= 5.3.0)
+    - VirgilCryptoFoundation (= 0.12.0)
+    - VirgilCryptoPythia (= 0.12.0)
+  - VirgilCrypto (5.3.0):
+    - VirgilCryptoFoundation (~> 0.12.0)
+  - VirgilCryptoFoundation (0.12.0):
+    - VSCCrypto/Common (= 0.12.0)
+    - VSCCrypto/Foundation (= 0.12.0)
+  - VirgilCryptoPythia (0.12.0):
+    - VirgilCryptoFoundation (= 0.12.0)
+    - VSCCrypto/Common (= 0.12.0)
+    - VSCCrypto/Foundation (= 0.12.0)
+    - VSCCrypto/Pythia (= 0.12.0)
+  - VSCCrypto/Common (0.12.0)
+  - VSCCrypto/Foundation (0.12.0)
+  - VSCCrypto/Pythia (0.12.0)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -258,7 +258,6 @@ DEPENDENCIES:
   - React-jsi (from `../node_modules/react-native/ReactCommon/jsi`)
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
-  - react-native-virgil-crypto (from `../node_modules/react-native-virgil-crypto`)
   - React-RCTActionSheet (from `../node_modules/react-native/Libraries/ActionSheetIOS`)
   - React-RCTAnimation (from `../node_modules/react-native/Libraries/NativeAnimation`)
   - React-RCTBlob (from `../node_modules/react-native/Libraries/Blob`)
@@ -272,10 +271,11 @@ DEPENDENCIES:
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - "RNCAsyncStorage (from `../node_modules/@react-native-community/async-storage`)"
   - RNKeychain (from `../node_modules/react-native-keychain`)
+  - RNVirgilCrypto (from `../node_modules/react-native-virgil-crypto`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  trunk:
     - boost-for-react-native
     - VirgilCrypto
     - VirgilCryptoFoundation
@@ -311,8 +311,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/jsiexecutor"
   React-jsinspector:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
-  react-native-virgil-crypto:
-    :path: "../node_modules/react-native-virgil-crypto"
   React-RCTActionSheet:
     :path: "../node_modules/react-native/Libraries/ActionSheetIOS"
   React-RCTAnimation:
@@ -337,6 +335,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-community/async-storage"
   RNKeychain:
     :path: "../node_modules/react-native-keychain"
+  RNVirgilCrypto:
+    :path: "../node_modules/react-native-virgil-crypto"
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
@@ -356,7 +356,6 @@ SPEC CHECKSUMS:
   React-jsi: 32285a21b1b24c36060493ed3057a34677d58d09
   React-jsiexecutor: 8909917ff7d8f21a57e443a866fd8d4560e50c65
   React-jsinspector: 111d7d342b07a904c400592e02a2b958f1098b60
-  react-native-virgil-crypto: 9b8219d22243c1babf98e8ed692fe6f928fedac5
   React-RCTActionSheet: 89b037c0fb7d2671607cb645760164e7e0c013f6
   React-RCTAnimation: e3cefa93c38c004c318f7ec04b883eb14b8b8235
   React-RCTBlob: d26ac0e313fbf14e7203473fd593ccaaeee8329e
@@ -367,14 +366,15 @@ SPEC CHECKSUMS:
   React-RCTText: e3ef6191cdb627855ff7fe8fa0c1e14094967fb8
   React-RCTVibration: fb54c732fd20405a76598e431aa2f8c2bf527de9
   ReactCommon: 5848032ed2f274fcb40f6b9ec24067787c42d479
-  RNCAsyncStorage: 60a80e72d95bf02a01cace55d3697d9724f0d77f
-  RNKeychain: 45dbd50d1ac4bd42c3740f76ffb135abf05746d0
-  VirgilCrypto: 309fa760ba0f21f160e7c54c58fca3d33a3913fe
-  VirgilCryptoFoundation: f182fd5859739dbe4e1a43432cb8c87f21f775e1
-  VirgilCryptoPythia: 1df83bc002b5a036559c10690a9d6d45c56ad6fa
-  VSCCrypto: 9ffdbed1f9c3fdd4baee7d02aa2baab4ca5d8dd2
+  RNCAsyncStorage: 44395cb9c7c1523104c2b499eb426ef7aff82bca
+  RNKeychain: 840f8e6f13be0576202aefcdffd26a4f54bfe7b5
+  RNVirgilCrypto: 986c5ef18de7e0a47791f50e90680d3c4c8407e5
+  VirgilCrypto: c2831582c5230eeb2adba2365336c768cd6d8c59
+  VirgilCryptoFoundation: 79f23a7ab6db642268d31bc63b0cf54db416f089
+  VirgilCryptoPythia: 4234b6f84de6fd2448faf6628ecdce84f43650a4
+  VSCCrypto: e2c8df89e0dc348c2713554f6a2c8864e1cf412d
   Yoga: 14927e37bd25376d216b150ab2a561773d57911f
 
-PODFILE CHECKSUM: ebb79000fb1f548039df809d4fb965c53bb2ecf8
+PODFILE CHECKSUM: 6fe0e8f2a84cc38f29f6d678d9695550f57e8934
 
-COCOAPODS: 1.7.5
+COCOAPODS: 1.8.4

--- a/examples/ReactNativeSample/package.json
+++ b/examples/ReactNativeSample/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ReactNativeSample",
-  "version": "0.7.1",
+  "version": "0.8.0-beta.0",
   "private": true,
   "scripts": {
     "android": "react-native run-android",
@@ -11,12 +11,12 @@
   },
   "dependencies": {
     "@react-native-community/async-storage": "^1.6.2",
-    "@virgilsecurity/e3kit-native": "0.7.1",
+    "@virgilsecurity/e3kit-native": "0.8.0-beta.0",
     "@virgilsecurity/key-storage-rn": "0.2.1",
     "react": "16.9.0",
     "react-native": "0.61.2",
     "react-native-keychain": "^4.0.1",
-    "react-native-virgil-crypto": "^0.4.0"
+    "react-native-virgil-crypto": "0.5.0"
   },
   "devDependencies": {
     "@babel/core": "^7.6.4",

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
     "packages/*"
   ],
   "useWorkspaces": true,
-  "version": "independent"
+  "version": "0.8.0-beta.0"
 }

--- a/packages/e3kit-native/package.json
+++ b/packages/e3kit-native/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@virgilsecurity/e3kit-native",
-    "version": "0.7.1",
+    "version": "0.8.0-beta.0",
     "description": "End-to-end encryption with multiple device support powered by Virgil Security",
     "main": "./dist/e3kit-native.cjs.js",
     "module": "./dist/e3kit-native.es.js",
@@ -19,15 +19,15 @@
     "dependencies": {
         "@types/abstract-leveldown": "^5.0.1",
         "@types/react-native": "^0.61.4",
-        "@virgilsecurity/e3kit-base": "0.7.1",
-        "@virgilsecurity/sdk-crypto": "0.4.5",
+        "@virgilsecurity/e3kit-base": "0.8.0-beta.0",
+        "@virgilsecurity/sdk-crypto": "0.5.0",
         "asyncstorage-down": "^4.2.0",
-        "virgil-sdk": "6.0.0-alpha.5"
+        "virgil-sdk": "6.0.0-alpha.6"
     },
     "devDependencies": {
         "@virgilsecurity/key-storage-rn": "0.2.1",
         "react-native-keychain": "^4.0.5",
-        "react-native-virgil-crypto": "0.4.0",
+        "react-native-virgil-crypto": "0.5.0",
         "rimraf": "^3.0.0",
         "rollup": "^1.29.1",
         "rollup-plugin-commonjs": "^10.1.0",
@@ -40,7 +40,7 @@
     },
     "peerDependencies": {
         "@virgilsecurity/key-storage-rn": "0.2.x",
-        "react-native-virgil-crypto": "0.4.x"
+        "react-native-virgil-crypto": "0.5.x"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/e3kit-native/src/EThree.ts
+++ b/packages/e3kit-native/src/EThree.ts
@@ -72,6 +72,7 @@ export class EThree extends AbstractEThree {
             keyEntryStorage,
             keyLoader,
             groupStorageLeveldown,
+            keyPairType: options.keyPairType,
         });
     }
 

--- a/packages/e3kit/package.json
+++ b/packages/e3kit/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@virgilsecurity/e3kit",
-    "version": "0.7.1",
+    "version": "0.8.0-beta.0",
     "description": "End-to-end encryption with multiple device support powered by Virgil Security",
     "main": "./dist/node.cjs.js",
     "module": "./dist/node.es.js",
@@ -28,9 +28,9 @@
         "prepare": "npm run clean && npm run build"
     },
     "dependencies": {
-        "@virgilsecurity/e3kit-browser": "0.7.1",
-        "@virgilsecurity/e3kit-native": "0.7.1",
-        "@virgilsecurity/e3kit-node": "0.7.1"
+        "@virgilsecurity/e3kit-browser": "0.8.0-beta.0",
+        "@virgilsecurity/e3kit-native": "0.8.0-beta.0",
+        "@virgilsecurity/e3kit-node": "0.8.0-beta.0"
     },
     "devDependencies": {
         "mkdirp": "^1.0.3",


### PR DESCRIPTION
### @virgilsecurity/e3kit-native
- Use `react-native-virgil-crypto@0.5.0`
- Initialize E3Kit with optional KeyPairType
- `authEncrypt` & `authDecrypt`

### @virgilsecurity/e3kit
- Use 0.8.0-beta.0 packages under the hood.