### PR TITLE
2.2.0

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,6 +1,5 @@
 {
     "*.{js,ts}": [
-        "eslint --fix",
-        "git add"
+        "eslint --fix"
     ]
 }

--- a/examples/ReactNativeSample/package.json
+++ b/examples/ReactNativeSample/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ReactNativeSample",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "private": true,
   "scripts": {
     "android": "react-native run-android",
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@react-native-community/async-storage": "^1.6.2",
-    "@virgilsecurity/e3kit-native": "^2.1.0",
+    "@virgilsecurity/e3kit-native": "^2.2.0",
     "@virgilsecurity/key-storage-rn": "^1.0.0",
     "react": "16.9.0",
     "react-native": "0.61.2",

--- a/examples/backend/package.json
+++ b/examples/backend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@virgilsecurity/example-backend",
-    "version": "2.1.1",
+    "version": "2.2.0",
     "description": "Sample backend for Virgil E3Kit SDK examples",
     "repository": "https://github.com/VirgilSecurity/virgil-e3kit-js/tree/master/packages/example-backend",
     "author": "Virgil Security Inc. <support@virgilsecurity.com>",

--- a/examples/create-react-app/package.json
+++ b/examples/create-react-app/package.json
@@ -1,12 +1,12 @@
 {
   "name": "create-react-app",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
-    "@virgilsecurity/e3kit-browser": "^2.1.0",
+    "@virgilsecurity/e3kit-browser": "^2.2.0",
     "react": "^16.13.0",
     "react-app-rewired": "^2.1.5",
     "react-dom": "^16.13.0",

--- a/examples/ionic/package.json
+++ b/examples/ionic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ionic",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "author": "Ionic Framework",
   "homepage": "https://ionicframework.com/",
   "scripts": {
@@ -24,7 +24,7 @@
     "@ionic-native/splash-screen": "^5.0.0",
     "@ionic-native/status-bar": "^5.0.0",
     "@ionic/angular": "^4.7.1",
-    "@virgilsecurity/e3kit-browser": "^2.1.0",
+    "@virgilsecurity/e3kit-browser": "^2.2.0",
     "core-js": "^2.5.4",
     "rxjs": "~6.5.1",
     "tslib": "^1.9.0",

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@virgilsecurity/example-node",
-    "version": "2.1.1",
+    "version": "2.2.0",
     "description": "Virgil E3Kit SDK + Node.js usage example",
     "repository": "https://github.com/VirgilSecurity/virgil-e3kit-js/tree/master/packages/example-node",
     "author": "Virgil Security Inc. <support@virgilsecurity.com>",
@@ -10,7 +10,7 @@
         "start": "node index.js"
     },
     "dependencies": {
-        "@virgilsecurity/e3kit-node": "^2.1.0",
+        "@virgilsecurity/e3kit-node": "^2.2.0",
         "dotenv": "^8.1.0"
     }
 }

--- a/examples/umd/package.json
+++ b/examples/umd/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@virgilsecurity/example-umd",
-    "version": "2.1.1",
+    "version": "2.2.0",
     "description": "Virgil E3Kit SDK UMD example",
     "repository": "https://github.com/VirgilSecurity/virgil-e3kit-js/tree/master/packages/example-umd",
     "author": "Virgil Security Inc. <support@virgilsecurity.com>",

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@virgilsecurity/example-webpack",
-    "version": "2.1.1",
+    "version": "2.2.0",
     "description": "Virgil E3Kit SDK + Webpack usage example",
     "repository": "https://github.com/VirgilSecurity/virgil-e3kit-js/tree/master/packages/example-webpack",
     "author": "Virgil Security Inc. <support@virgilsecurity.com>",

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
     "packages/*"
   ],
   "useWorkspaces": true,
-  "version": "2.1.1"
+  "version": "2.2.0"
 }

--- a/packages/e3kit-base/package.json
+++ b/packages/e3kit-base/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@virgilsecurity/e3kit-base",
-    "version": "2.1.1",
+    "version": "2.2.0",
     "description": "End-to-end encryption with multiple device support powered by Virgil Security",
     "main": "./dist/e3kit-base.cjs.js",
     "module": "./dist/e3kit-base.es.js",

--- a/packages/e3kit-browser/package.json
+++ b/packages/e3kit-browser/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@virgilsecurity/e3kit-browser",
-    "version": "2.1.1",
+    "version": "2.2.0",
     "description": "End-to-end encryption with multiple device support powered by Virgil Security",
     "main": "./browser.cjs.js",
     "module": "./browser.es.js",
@@ -22,7 +22,7 @@
     },
     "dependencies": {
         "@types/level-js": "^4.0.1",
-        "@virgilsecurity/e3kit-base": "^2.1.0",
+        "@virgilsecurity/e3kit-base": "^2.2.0",
         "@virgilsecurity/pythia-crypto": "^1.1.0",
         "level-js": "^5.0.1",
         "virgil-crypto": "^4.1.0",

--- a/packages/e3kit-browser/src/EThree.ts
+++ b/packages/e3kit-browser/src/EThree.ts
@@ -32,7 +32,8 @@ import {
     ICard,
     IPublicKey,
     VirgilPrivateKey,
-    CryptoLibraryOptions,
+    FoundationLibraryOptions,
+    PythiaLibraryOptions,
     EThreeInitializeOptions,
     EThreeCtorOptions,
     EncryptFileOptions,
@@ -58,7 +59,8 @@ export class EThree extends AbstractEThree {
         getToken: () => Promise<string>,
         options: EThreeInitializeOptions = {},
     ): Promise<EThree> {
-        const { cryptoOptions, pythiaOptions } = EThree.getCryptoLibraryOptions(options);
+        const cryptoOptions = EThree.getFoundationLibraryOptions(options);
+        const pythiaOptions = EThree.getPythiaLibraryOptions(options);
         await Promise.all([initCrypto(cryptoOptions), initPythia(pythiaOptions)]);
 
         if (typeof getToken !== 'function') {
@@ -79,9 +81,9 @@ export class EThree extends AbstractEThree {
         return new EThree(identity, opts);
     }
 
-    static async derivePasswords(password: Data, options: CryptoLibraryOptions = {}) {
-        const { cryptoOptions, pythiaOptions } = EThree.getCryptoLibraryOptions(options);
-        await Promise.all([initCrypto(cryptoOptions), initPythia(pythiaOptions)]);
+    static async derivePasswords(password: Data, options: FoundationLibraryOptions = {}) {
+        const cryptoOptions = EThree.getFoundationLibraryOptions(options);
+        await initCrypto(cryptoOptions);
         const crypto = new VirgilCrypto();
         const hash1 = crypto.calculateHash(password, HashAlgorithm.SHA256);
         const hash2 = crypto.calculateHash(hash1, HashAlgorithm.SHA512);
@@ -336,17 +338,19 @@ export class EThree extends AbstractEThree {
     /**
      * @hidden
      */
-    private static getCryptoLibraryOptions(options: CryptoLibraryOptions) {
-        const cryptoOptions = options.foundationWasmPath
+    private static getFoundationLibraryOptions(options: FoundationLibraryOptions) {
+        return options.foundationWasmPath
             ? { foundation: [{ locateFile: () => options.foundationWasmPath }] }
             : undefined;
-        const pythiaOptions = options.pythiaWasmPath
+    }
+
+    /**
+     * @hidden
+     */
+    private static getPythiaLibraryOptions(options: PythiaLibraryOptions) {
+        return options.pythiaWasmPath
             ? { pythia: [{ locateFile: () => options.pythiaWasmPath }] }
             : undefined;
-        return {
-            cryptoOptions,
-            pythiaOptions,
-        };
     }
 
     /**

--- a/packages/e3kit-browser/src/EThree.ts
+++ b/packages/e3kit-browser/src/EThree.ts
@@ -9,7 +9,13 @@ import {
 } from '@virgilsecurity/e3kit-base';
 import { initPythia, VirgilBrainKeyCrypto } from '@virgilsecurity/pythia-crypto';
 import leveljs from 'level-js';
-import { initCrypto, VirgilCardCrypto, VirgilCrypto, VirgilPublicKey } from 'virgil-crypto';
+import {
+    initCrypto,
+    VirgilCardCrypto,
+    VirgilCrypto,
+    VirgilPublicKey,
+    HashAlgorithm,
+} from 'virgil-crypto';
 import { CachingJwtProvider, CardManager, KeyEntryStorage, VirgilCardVerifier } from 'virgil-sdk';
 
 import {
@@ -75,6 +81,15 @@ export class EThree extends AbstractEThree {
         });
         const identity = token.identity();
         return new EThree(identity, opts);
+    }
+
+    static derivePasswords(password: Data) {
+        const crypto = new VirgilCrypto();
+        const hash1 = crypto.calculateHash(password, HashAlgorithm.SHA256);
+        const hash2 = crypto.calculateHash(hash1, HashAlgorithm.SHA512);
+        const loginPassword = hash2.slice(0, 32);
+        const backupPassword = hash2.slice(32, 64);
+        return { loginPassword, backupPassword };
     }
 
     /**

--- a/packages/e3kit-browser/src/types.ts
+++ b/packages/e3kit-browser/src/types.ts
@@ -18,10 +18,13 @@ export type KeyPairType = import('virgil-crypto').KeyPairType;
 export type VirgilCrypto = import('virgil-crypto').VirgilCrypto;
 export type VirgilPrivateKey = import('virgil-crypto').VirgilPrivateKey;
 
-export interface EThreeInitializeOptions extends EThreeBaseInitializeOptions {
-    keyPairType?: KeyPairType;
+export interface CryptoLibraryOptions {
     foundationWasmPath?: string;
     pythiaWasmPath?: string;
+}
+
+export interface EThreeInitializeOptions extends EThreeBaseInitializeOptions, CryptoLibraryOptions {
+    keyPairType?: KeyPairType;
 }
 
 export interface EThreeCtorOptions extends EThreeBaseCtorOptions {

--- a/packages/e3kit-browser/src/types.ts
+++ b/packages/e3kit-browser/src/types.ts
@@ -18,12 +18,18 @@ export type KeyPairType = import('virgil-crypto').KeyPairType;
 export type VirgilCrypto = import('virgil-crypto').VirgilCrypto;
 export type VirgilPrivateKey = import('virgil-crypto').VirgilPrivateKey;
 
-export interface CryptoLibraryOptions {
+export interface FoundationLibraryOptions {
     foundationWasmPath?: string;
+}
+
+export interface PythiaLibraryOptions {
     pythiaWasmPath?: string;
 }
 
-export interface EThreeInitializeOptions extends EThreeBaseInitializeOptions, CryptoLibraryOptions {
+export interface EThreeInitializeOptions
+    extends EThreeBaseInitializeOptions,
+        FoundationLibraryOptions,
+        PythiaLibraryOptions {
     keyPairType?: KeyPairType;
 }
 

--- a/packages/e3kit-native/package.json
+++ b/packages/e3kit-native/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@virgilsecurity/e3kit-native",
-    "version": "2.1.1",
+    "version": "2.2.0",
     "description": "End-to-end encryption with multiple device support powered by Virgil Security",
     "main": "./dist/e3kit-native.cjs.js",
     "module": "./dist/e3kit-native.es.js",
@@ -19,7 +19,7 @@
     "dependencies": {
         "@types/abstract-leveldown": "^5.0.1",
         "@types/react-native": "^0.61.4",
-        "@virgilsecurity/e3kit-base": "^2.1.0",
+        "@virgilsecurity/e3kit-base": "^2.2.0",
         "@virgilsecurity/sdk-crypto": "^1.0.0",
         "asyncstorage-down": "^4.2.0",
         "virgil-sdk": "^6.1.0"

--- a/packages/e3kit-native/src/EThree.ts
+++ b/packages/e3kit-native/src/EThree.ts
@@ -7,11 +7,11 @@ import {
 } from '@virgilsecurity/e3kit-base';
 import { ReactNativeKeychainStorageAdapter } from '@virgilsecurity/key-storage-rn';
 import { VirgilCardCrypto } from '@virgilsecurity/sdk-crypto';
-import { virgilCrypto, virgilBrainKeyCrypto } from 'react-native-virgil-crypto';
+import { virgilCrypto, virgilBrainKeyCrypto, HashAlgorithm } from 'react-native-virgil-crypto';
 import { CachingJwtProvider, CardManager, VirgilCardVerifier, KeyEntryStorage } from 'virgil-sdk';
 import asyncstorageDown from 'asyncstorage-down';
 
-import { IPublicKey, EThreeCtorOptions, EThreeInitializeOptions } from './types';
+import { Data, IPublicKey, EThreeCtorOptions, EThreeInitializeOptions } from './types';
 
 import './asyncstoragedown-clear-polyfill';
 
@@ -101,6 +101,14 @@ export class EThree extends AbstractEThree {
         });
         const identity = token.identity();
         return new EThree(identity, opts);
+    }
+
+    static derivePasswords(password: Data) {
+        const hash1 = virgilCrypto.calculateHash(password, HashAlgorithm.SHA256);
+        const hash2 = virgilCrypto.calculateHash(hash1, HashAlgorithm.SHA512);
+        const loginPassword = hash2.slice(0, 32);
+        const backupPassword = hash2.slice(32, 64);
+        return { loginPassword, backupPassword };
     }
 
     /**

--- a/packages/e3kit-native/src/types.ts
+++ b/packages/e3kit-native/src/types.ts
@@ -1,3 +1,4 @@
+export type Data = import('@virgilsecurity/e3kit-base').Data;
 export type IPublicKey = import('@virgilsecurity/e3kit-base').IPublicKey;
 export type EThreeInitializeOptions = import('@virgilsecurity/e3kit-base').EThreeInitializeOptions;
 export type EThreeCtorOptions = import('@virgilsecurity/e3kit-base').EThreeCtorOptions;

--- a/packages/e3kit-node/package.json
+++ b/packages/e3kit-node/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@virgilsecurity/e3kit-node",
-    "version": "2.1.1",
+    "version": "2.2.0",
     "description": "End-to-end encryption with multiple device support powered by Virgil Security",
     "main": "./dist/node.cjs.js",
     "module": "./dist/node.es.js",
@@ -19,7 +19,7 @@
     "dependencies": {
         "@types/leveldown": "^4.0.0",
         "@types/mkdirp": "^0.5.2",
-        "@virgilsecurity/e3kit-base": "^2.1.0",
+        "@virgilsecurity/e3kit-base": "^2.2.0",
         "@virgilsecurity/pythia-crypto": "^1.1.0",
         "is-invalid-path": "^1.0.2",
         "leveldown": "^5.4.1",

--- a/packages/e3kit-node/src/EThree.ts
+++ b/packages/e3kit-node/src/EThree.ts
@@ -11,10 +11,16 @@ import { initPythia, VirgilBrainKeyCrypto } from '@virgilsecurity/pythia-crypto'
 import isInvalidPath from 'is-invalid-path';
 import leveldown from 'leveldown';
 import mkdirp from 'mkdirp';
-import { initCrypto, VirgilCardCrypto, VirgilCrypto, VirgilPublicKey } from 'virgil-crypto';
+import {
+    initCrypto,
+    VirgilCardCrypto,
+    VirgilCrypto,
+    VirgilPublicKey,
+    HashAlgorithm,
+} from 'virgil-crypto';
 import { CachingJwtProvider, CardManager, KeyEntryStorage, VirgilCardVerifier } from 'virgil-sdk';
 
-import { IPublicKey, EThreeInitializeOptions, EThreeCtorOptions } from './types';
+import { Data, IPublicKey, EThreeInitializeOptions, EThreeCtorOptions } from './types';
 
 export class EThree extends AbstractEThree {
     /**
@@ -108,6 +114,15 @@ export class EThree extends AbstractEThree {
         });
         const identity = token.identity();
         return new EThree(identity, opts);
+    }
+
+    static derivePasswords(password: Data) {
+        const crypto = new VirgilCrypto();
+        const hash1 = crypto.calculateHash(password, HashAlgorithm.SHA256);
+        const hash2 = crypto.calculateHash(hash1, HashAlgorithm.SHA512);
+        const loginPassword = hash2.slice(0, 32);
+        const backupPassword = hash2.slice(32, 64);
+        return { loginPassword, backupPassword };
     }
 
     /**

--- a/packages/e3kit-node/src/types.ts
+++ b/packages/e3kit-node/src/types.ts
@@ -1,3 +1,4 @@
+export type Data = import('@virgilsecurity/e3kit-base').Data;
 export type IPublicKey = import('@virgilsecurity/e3kit-base').IPublicKey;
 export type EThreeBaseInitializeOptions = import('@virgilsecurity/e3kit-base').EThreeInitializeOptions;
 export type EThreeBaseCtorOptions = import('@virgilsecurity/e3kit-base').EThreeCtorOptions;

--- a/packages/e3kit-node/src/types.ts
+++ b/packages/e3kit-node/src/types.ts
@@ -5,12 +5,18 @@ export type EThreeBaseCtorOptions = import('@virgilsecurity/e3kit-base').EThreeC
 
 export type KeyPairType = import('virgil-crypto').KeyPairType;
 
-export interface CryptoLibraryOptions {
+export interface FoundationLibraryOptions {
     foundationWasmPath?: string;
+}
+
+export interface PythiaLibraryOptions {
     pythiaWasmPath?: string;
 }
 
-export interface EThreeInitializeOptions extends EThreeBaseInitializeOptions, CryptoLibraryOptions {
+export interface EThreeInitializeOptions
+    extends EThreeBaseInitializeOptions,
+        FoundationLibraryOptions,
+        PythiaLibraryOptions {
     keyPairType?: KeyPairType;
 }
 

--- a/packages/e3kit-node/src/types.ts
+++ b/packages/e3kit-node/src/types.ts
@@ -5,10 +5,13 @@ export type EThreeBaseCtorOptions = import('@virgilsecurity/e3kit-base').EThreeC
 
 export type KeyPairType = import('virgil-crypto').KeyPairType;
 
-export interface EThreeInitializeOptions extends EThreeBaseInitializeOptions {
-    keyPairType?: KeyPairType;
+export interface CryptoLibraryOptions {
     foundationWasmPath?: string;
     pythiaWasmPath?: string;
+}
+
+export interface EThreeInitializeOptions extends EThreeBaseInitializeOptions, CryptoLibraryOptions {
+    keyPairType?: KeyPairType;
 }
 
 export interface EThreeCtorOptions extends EThreeBaseCtorOptions {

--- a/packages/e3kit-tests/package.json
+++ b/packages/e3kit-tests/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@virgilsecurity/e3kit-tests",
-    "version": "2.1.1",
+    "version": "2.2.0",
     "description": "Virgil E3Kit SDK tests",
     "repository": "https://github.com/VirgilSecurity/virgil-e3kit-js/tree/master/packages/e3kit-tests",
     "author": "Virgil Security Inc. <support@virgilsecurity.com>",
@@ -16,8 +16,8 @@
         "@types/is-buffer": "^2.0.0",
         "@types/mocha": "^5.2.7",
         "@types/uuid": "^3.4.6",
-        "@virgilsecurity/e3kit-browser": "^2.1.0",
-        "@virgilsecurity/e3kit-node": "^2.1.0",
+        "@virgilsecurity/e3kit-browser": "^2.2.0",
+        "@virgilsecurity/e3kit-node": "^2.2.0",
         "@virgilsecurity/keyknox": "^1.0.0",
         "@virgilsecurity/pythia-crypto": "^1.1.0",
         "chai": "^4.2.0",

--- a/packages/e3kit-tests/src/common/EThree.test.ts
+++ b/packages/e3kit-tests/src/common/EThree.test.ts
@@ -121,8 +121,8 @@ describe('EThree', () => {
     describe('derivePasswords', () => {
         it('derives passwords', async () => {
             const password = 'password';
-            const loginPasswordBase64 = '82e04faeb478cd77c6561544437ffb06e18ec0e61d8=';
-            const backupPasswordBase64 = 'XWm+9+dNm9HuetvNXG9XneXufeneOt9X/O9OPHvHGnM=';
+            const loginPasswordBase64 = '8AfkqegTXFuyufUkwZ7u9s6x8xc9CjtZANqIjmueS40=';
+            const backupPasswordBase64 = 'R/NHBt3Bv4ZIRPNEFirMH5GnRS1F/Rz64mYq1f+g+aU=';
             const { loginPassword, backupPassword } = await EThree.derivePasswords(password);
             expect(loginPassword.toString('base64')).equals(loginPasswordBase64);
             expect(backupPassword.toString('base64')).equals(backupPasswordBase64);

--- a/packages/e3kit-tests/src/common/EThree.test.ts
+++ b/packages/e3kit-tests/src/common/EThree.test.ts
@@ -118,6 +118,13 @@ describe('EThree', () => {
         return storage;
     };
 
+    describe('derivePasswords', () => {
+        it('derives passwords', () => {
+            const { loginPassword, backupPassword } = EThree.derivePasswords('password');
+            expect(loginPassword.equals(backupPassword)).to.be.false;
+        });
+    });
+
     describe('EThree.register()', () => {
         it('STA-9 has no local key, has no card', async () => {
             const identity = uuid();

--- a/packages/e3kit-tests/src/common/EThree.test.ts
+++ b/packages/e3kit-tests/src/common/EThree.test.ts
@@ -119,8 +119,8 @@ describe('EThree', () => {
     };
 
     describe('derivePasswords', () => {
-        it('derives passwords', () => {
-            const { loginPassword, backupPassword } = EThree.derivePasswords('password');
+        it('derives passwords', async () => {
+            const { loginPassword, backupPassword } = await EThree.derivePasswords('password');
             expect(loginPassword.equals(backupPassword)).to.be.false;
         });
     });

--- a/packages/e3kit-tests/src/common/EThree.test.ts
+++ b/packages/e3kit-tests/src/common/EThree.test.ts
@@ -120,8 +120,12 @@ describe('EThree', () => {
 
     describe('derivePasswords', () => {
         it('derives passwords', async () => {
-            const { loginPassword, backupPassword } = await EThree.derivePasswords('password');
-            expect(loginPassword.equals(backupPassword)).to.be.false;
+            const password = 'password';
+            const loginPasswordBase64 = '82e04faeb478cd77c6561544437ffb06e18ec0e61d8=';
+            const backupPasswordBase64 = 'XWm+9+dNm9HuetvNXG9XneXufeneOt9X/O9OPHvHGnM=';
+            const { loginPassword, backupPassword } = await EThree.derivePasswords(password);
+            expect(loginPassword.toString('base64')).equals(loginPasswordBase64);
+            expect(backupPassword.toString('base64')).equals(backupPasswordBase64);
         });
     });
 


### PR DESCRIPTION
What's new:
- Add `derivePasswords` method
  Usage - Node.js or browser:
  ```js
  const { loginPassword, backupPassword } = await EThree.derivePasswords('password');
  ```
  Usage - React Native:
  ```js
  const { loginPassword, backupPassword } = EThree.derivePasswords('password');
  ```