### PR TITLE
Close leveldown

### DIFF
--- a/packages/e3kit-base/src/AbstractEThree.ts
+++ b/packages/e3kit-base/src/AbstractEThree.ts
@@ -171,6 +171,10 @@ export abstract class AbstractEThree {
         await this.onPrivateKeyDeleted();
     }
 
+    async close() {
+        await this.groupManager.close();
+    }
+
     /**
      * Delete private key saved in Virgil Keyknox Storage.
      * @returns {Promise<void>} - Promise that is resolved if everything went fine.

--- a/packages/e3kit-base/src/GroupLocalStorage.ts
+++ b/packages/e3kit-base/src/GroupLocalStorage.ts
@@ -81,6 +81,12 @@ export class GroupLocalStorage {
         await this._db.clear();
     }
 
+    async close() {
+        if (this._db.isOpen()) {
+            await this._db.close();
+        }
+    }
+
     async addParticipants(sessionId: string, participants: string[]) {
         const [ticket] = await this.retrieveNLastTickets(sessionId, 1);
         const newTicket: Ticket = {

--- a/packages/e3kit-base/src/GroupManager.ts
+++ b/packages/e3kit-base/src/GroupManager.ts
@@ -1,5 +1,6 @@
 import {
     CloudGroupTicketStorage,
+    GroupTicketAlreadyExistsError,
     KeyknoxManager,
     KeyknoxCrypto,
     KeyknoxClient,
@@ -42,7 +43,20 @@ export class GroupManager {
 
     async store(ticket: Ticket, cards: ICard[]) {
         const cloudTicketStorage = await this.getCloudTicketStorage();
-        await cloudTicketStorage.store(ticket.groupSessionMessage, cards);
+
+        try {
+            await cloudTicketStorage.store(ticket.groupSessionMessage, cards);
+        } catch (error) {
+            if (error instanceof GroupTicketAlreadyExistsError) {
+                throw new GroupError(
+                    GroupErrorCode.GroupExists,
+                    'Group with given id already exists',
+                );
+            } else {
+                throw error;
+            }
+        }
+
         const group = new Group({
             initiator: this.selfIdentity,
             tickets: [ticket],

--- a/packages/e3kit-base/src/GroupManager.ts
+++ b/packages/e3kit-base/src/GroupManager.ts
@@ -191,6 +191,11 @@ export class GroupManager {
         await localGroupStorage.reset();
     }
 
+    async close() {
+        const localGroupStorage = await this.getLocalGroupStorage();
+        await localGroupStorage.close();
+    }
+
     private get selfIdentity() {
         return this._selfIdentity;
     }

--- a/packages/e3kit-base/src/errors.ts
+++ b/packages/e3kit-base/src/errors.ts
@@ -187,6 +187,7 @@ export enum GroupErrorCode {
     MessageNotFromThisGroup = 9,
     GroupIsOutdated = 10,
     NoAccess = 11,
+    GroupExists = 12,
 }
 
 export class GroupError extends SdkError {

--- a/packages/e3kit-node/src/index.ts
+++ b/packages/e3kit-node/src/index.ts
@@ -20,6 +20,8 @@ export {
     GroupErrorCode,
     GroupError,
     MissingPrivateKeyError,
+    UsersNotFoundError,
+    UsersFoundWithMultipleCardsError,
     // types
     NodeBuffer,
     Data,


### PR DESCRIPTION
I'm not sure my solutions are the best here. I'll gladly work with you to bring this up to par. I know this needs tests, but I want to verify this is a PR you'd be willing to merge before I move forward with that.

This PR addressed a few issues:

- Add function to close leveldown instance. fixes #131 
- Catch `GroupTicketAlreadyExistsError` from knox
- Expose additional error types for e3kit-node

