### PR TITLE
Fix Import Path

### DIFF
--- a/packages/e3kit-node/src/index.ts
+++ b/packages/e3kit-node/src/index.ts
@@ -40,6 +40,6 @@ export {
     GroupInfo,
     RawGroup,
 } from '@virgilsecurity/e3kit-base';
-export { KeyPairType } from 'virgil-crypto';
+export { KeyPairType } from 'virgil-crypto/dist/types';
 export { EThree } from './EThree';
 export { EThreeInitializeOptions, EThreeCtorOptions } from './types';


### PR DESCRIPTION
Fix for related issue. It seems that once it is compiled, Node requires the complete path, even though it is exported.
https://github.com/VirgilSecurity/virgil-e3kit-js/pull/167#issuecomment-1870586239